### PR TITLE
Add small .a file with filetable

### DIFF
--- a/ar/filetable_spaces.a
+++ b/ar/filetable_spaces.a
@@ -1,0 +1,18 @@
+!<arch>
+//                                              66        `
+ longgggggggggggggggggspaces/
+looooooooooooonnnnnnnnggggggggname/
+aaaa/           0           0     0     644     5         `
+aaaa
+
+bbbb/           0           0     0     644     5         `
+bbbb
+
+/0              0           0     0     644     10        `
+longspace
+/30             0           0     0     644     9         `
+longname
+
+ s_spaces/      0           0     0     644     11        `
+shortspace
+


### PR DESCRIPTION
**Detailed description**

There was only one ar file and it lacked a file name table. This will add a second ar file, that will have long names that require a table lookup. A couple names start with a leading space. Since space is used as a separator, bad logic could cause them to be cut off. 

**Test plan**

PR with new tests at https://github.com/radareorg/radare2/pull/18180


**Closing issues**
